### PR TITLE
build: add dependency on gio-unix

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,10 @@ executable('permission-viewer',
     'permission-viewer-app.c',
     'permission-viewer-win.c',
   ],
-  dependencies: dependency('gtk+-3.0'),
+  dependencies: [
+    dependency('gtk+-3.0'),
+    dependency('gio-unix-2.0'),
+  ],
   install: true,
 )
 


### PR DESCRIPTION
When trying to build the package on NixOS, it fails with

```
xdp-dbus.c:16:12: fatal error: gio/gunixfdlist.h: No such file or directory
 #  include <gio/gunixfdlist.h>
            ^~~~~~~~~~~~~~~~~~~
compilation terminated.
```

`gio-unix-2.0` dependency needs to be listed explicitly.